### PR TITLE
added munin_node_plugins_disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ If the name of the resulting plugin does not match the name of the munin plugin 
       - name: if_eth0
         plugin: if_
 
+You can also disable plugins using the `munin_node_plugins_disabled` list, like so:
+
+    munin_node_plugins_disabled:
+      - name: entropy
+      - name: open_inodes
+      - name: if_err_tap0
+
+The role will then remove the named symlink under `{{ munin_plugin_dest_path }}`.
+
 #### Plugin settings
 
 If you need to add plugin configuration for plugins you've added via `munin_node_plugins`, you can do so with a simple hashmap that has the plugin name (which will be the `[plugin]` section in the resulting configuration file), and a list of variable names and values. For example:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,12 @@ munin_node_plugins: []
   # - name: ps_test
   #   plugin: ps_
 
+# List of munin plugins to disable.
+munin_node_plugins_disabled: []
+  # - name: entropy
+  # - name: open_inodes
+  # - name: if_err_tap0
+
 # Plugin configuration options (the key is the plugin heading, items in the
 # array will be options for the plugin).
 munin_node_config: {

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,5 +36,12 @@
   with_items: "{{ munin_node_plugins }}"
   notify: restart munin-node
 
+- name: Disable dedicated plugins.
+  file:
+    path: "{{ munin_plugin_dest_path }}{{ item.name }}"
+    state: absent
+  with_items: "{{ munin_node_plugins_disabled }}"
+  notify: restart munin-node
+
 - name: Ensure munin-node is running.
   service: name=munin-node state=started enabled=yes


### PR DESCRIPTION
Hello

regarding to issue #5, this is a small addon to allow disabling a plugin enabled by the default installer.

Maybe you have an idea how to solve this smarter:

```
munin_node_plugins_disabled:
  - name: if_tap0
  - name: if_tap1
  - name: if_tap2
  - name: if_tap3
  - name: if_tap4
  - name: if_tap5
  - name: if_tap6
  - name: if_tap7
  - name: if_tap8
  - name: if_tap9
  - name: if_err_tap0
  - name: if_err_tap1
  - name: if_err_tap2
  - name: if_err_tap3
  - name: if_err_tap4
  - name: if_err_tap5
  - name: if_err_tap6
  - name: if_err_tap7
  - name: if_err_tap8
  - name: if_err_tap9
```

Maybe a Jinja2 feature may help here?
Next to this, disabling works as expected/requested.

EDIT:
I forgot to mention that this large block above takes quite some time on many nodes as any file/link gets checked (at least the first run).

Best regards

jardleex
