### PR TITLE
Add support for munin-async and other minor changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ env:
     - MOLECULE_DISTRO: centos7
       MOLECULE_PLAYBOOK: playbook-vars.yml
 
+    - MOLECULE_DISTRO: centos7
+      MOLECULE_PLAYBOOK: playbook-async.yml
+
 install:
   # Install test dependencies.
   - pip install molecule docker

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Set this explicitly if the munin master doesn't report the correct hostname when
 
     munin_node_allowed_ips:
       - '^127\.0\.0\.1$'
+      - '^::1$'
 
 A list of IP addresses formatted as a python-style regular expression. Must use single quotes to allow the proper regex escaping to pass through to the configuration file. Hosts with these IP addresses will be allowed to connect to the server and get detailed system stats via munin-node.
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/geerlingguy/ansible-role-munin-node.svg?branch=master)](https://travis-ci.org/geerlingguy/ansible-role-munin-node)
 
 Installs munin-node, a monitoring system endpoint, on RedHat/CentOS or Debian/Ubuntu Linux servers.
+It can optionally install munin-async, for asynchronous fetching over SSH.
 
 ## Requirements
 
@@ -34,6 +35,17 @@ A list of IP networks in CIDR format, for instance `10.0.0.0/8`. Hosts with an I
     munin_node_denied_cidrs: []
 
 A list of IP networks in CIDR format, for instance `10.42.0.0/16`. Hosts with an IP address in one of these networks will be denied access to the server. This takes precedence over `munin_node_allowed_cidrs`: an IP address that matches both a network in `munin_node_allowed_cidrs` and a network in `munin_node_denied_cidrs` will be denied access.
+
+### Munin-async configuration
+
+    munin_node_async: false
+
+Whether to install and setup `munin-async`, disabled by default.
+
+    munin_node_async_sshpubkeys: []
+
+A list of SSH public key that will be installed in the munin-async user home, to allow the munin master node to connect via SSH.
+Should only be used if `munin_node_async` is true.
 
 ### Munin Plugin Configuration
 
@@ -72,6 +84,9 @@ None.
 ## Example Playbook
 
     - hosts: servers
+      vars:
+        munin_node_async: true
+        munin_node_async_sshpubkeys: ['ssh-rsa AAAAB3NzaC...']
       roles:
         - { role: geerlingguy.munin-node }
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ Set this explicitly if the munin master doesn't report the correct hostname when
 
 A list of IP addresses formatted as a python-style regular expression. Must use single quotes to allow the proper regex escaping to pass through to the configuration file. Hosts with these IP addresses will be allowed to connect to the server and get detailed system stats via munin-node.
 
+    munin_node_allowed_cidrs: []
+
+A list of IP networks in CIDR format, for instance `10.0.0.0/8`. Hosts with an IP address in one of these networks will be allowed to connect to the server and get detailed system stats via munin-node.
+
+    munin_node_denied_cidrs: []
+
+A list of IP networks in CIDR format, for instance `10.42.0.0/16`. Hosts with an IP address in one of these networks will be denied access to the server. This takes precedence over `munin_node_allowed_cidrs`: an IP address that matches both a network in `munin_node_allowed_cidrs` and a network in `munin_node_denied_cidrs` will be denied access.
+
 ### Munin Plugin Configuration
 
 You can enable plugins using the `munin_node_plugins` list, like so:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,9 @@ munin_node_allowed_ips:
   - '^127\.0\.0\.1$'
   - '^::1$'
 
+munin_node_allowed_cidrs: []
+munin_node_denied_cidrs: []
+
 # Source and destination of munin plugins.
 munin_plugin_src_path: /usr/share/munin/plugins/
 munin_plugin_dest_path: /etc/munin/plugins/

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,3 +32,6 @@ munin_node_config: {
 #   "env.name": "bash"
 # }
 }
+
+munin_node_async: false
+munin_node_async_sshpubkeys: []

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,7 @@
 ---
 - name: restart munin-node
   service: name=munin-node state=restarted
+
+- name: restart munin-async
+  service: name={{ munin_node_async_service }} state=restarted
+  when: munin_node_async

--- a/molecule/default/playbook-async.yml
+++ b/molecule/default/playbook-async.yml
@@ -1,0 +1,25 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+
+  vars:
+    munin_node_async: true
+    munin_node_async_sshpubkeys: ['ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP/8Qg23DDX/E5wMxO6vW+bxZKED3eKpXS+0QlYdN+uK']
+
+  pre_tasks:
+    - name: Update apt cache.
+      apt: update_cache=true cache_valid_time=600
+      when: ansible_os_family == 'Debian'
+      changed_when: false
+
+    - name: Install test dependencies (Debian).
+      package: name=netcat state=present
+      when: ansible_os_family == 'Debian'
+
+    - name: Install test dependencies (RedHat).
+      package: name=nc state=present
+      when: ansible_os_family == 'RedHat'
+
+  roles:
+    - role: geerlingguy.munin-node

--- a/molecule/default/playbook-vars.yml
+++ b/molecule/default/playbook-vars.yml
@@ -4,6 +4,8 @@
   become: true
 
   vars:
+    munin_node_allowed_cidrs: ['10.0.0.0/8', '2001:db8::/32']
+    munin_node_denied_cidrs: ['10.42.0.0/16', '2001:db8:42::/48']
     munin_node_plugins:
       - name: uptime
       - name: if_eth1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,11 +4,25 @@
 
 - name: Ensure munin-node is installed (RedHat).
   yum: name=munin-node state=present enablerepo=epel
-  when: ansible_os_family == 'RedHat'
+  when: ansible_os_family == 'RedHat' and not munin_node_async
+
+- name: Ensure munin-node and munin-async are installed (RedHat).
+  yum: name={{ item }} state=present
+  with_items:
+  - munin-node
+  - munin-async
+  when: ansible_os_family == 'RedHat' and munin_node_async
 
 - name: Ensure munin-node is installed (Debian).
   apt: name=munin-node state=present
-  when: ansible_os_family == 'Debian'
+  when: ansible_os_family == 'Debian' and not munin_node_async
+
+- name: Ensure munin-node and munin-async are installed (Debian).
+  apt: name={{ item }} state=present
+  with_items:
+  - munin-node
+  - munin-async
+  when: ansible_os_family == 'Debian' and munin_node_async
 
 - name: Copy munin-node configuration.
   template:
@@ -17,7 +31,9 @@
     owner: root
     group: root
     mode: 0644
-  notify: restart munin-node
+  notify:
+    - restart munin-node
+    - restart munin-async
 
 - name: Generate plugin configuration.
   template:
@@ -26,7 +42,9 @@
     owner: root
     group: root
     mode: 0644
-  notify: restart munin-node
+  notify:
+    - restart munin-node
+    - restart munin-async
 
 - name: Enable additional plugins.
   file:
@@ -34,7 +52,38 @@
     src: "{{ munin_plugin_src_path }}{{ item.plugin | default( item.name ) }}"
     state: link
   with_items: "{{ munin_node_plugins }}"
-  notify: restart munin-node
+  notify:
+    - restart munin-node
+    - restart munin-async
+
+- name: Create munin-async user on CentOS
+  user:
+    name: "{{ munin_node_async_user }}"
+    system: yes
+    home: "{{ munin_node_async_home }}"
+  when: ansible_os_family == 'RedHat' and munin_node_async
+
+- name: Ensure ~/.ssh/ exists for munin-async user
+  file:
+    path: "{{ munin_node_async_home }}/.ssh/"
+    state: directory
+    owner: "{{ munin_node_async_user }}"
+    group: "{{ munin_node_async_group }}"
+    mode: 0700
+  when: munin_node_async
+
+- name: Add SSH key to munin-async user
+  template:
+    src: munin-async-authorized_keys.j2
+    dest: "{{ munin_node_async_home }}/.ssh/authorized_keys"
+    owner: "{{ munin_node_async_user }}"
+    group: "{{ munin_node_async_group }}"
+    mode: 0600
+  when: munin_node_async and munin_node_async_sshpubkeys
 
 - name: Ensure munin-node is running.
   service: name=munin-node state=started enabled=yes
+
+- name: Ensure munin-async is running.
+  service: name={{ munin_node_async_service }} state=started enabled=yes
+  when: munin_node_async

--- a/templates/munin-async-authorized_keys.j2
+++ b/templates/munin-async-authorized_keys.j2
@@ -1,0 +1,3 @@
+{% for sshpubkey in munin_node_async_sshpubkeys %}
+no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty,no-user-rc,command="/usr/share/munin/munin-async --spoolfetch" {{ sshpubkey }}
+{% endfor %}

--- a/templates/munin-node.conf.j2
+++ b/templates/munin-node.conf.j2
@@ -21,8 +21,7 @@ group root
 # timeout 60
 
 # Regexps for files to ignore
-ignore_file ~$
-#ignore_file [#~]$  # FIX doesn't work. '#' starts a comment
+ignore_file [\#~]$
 ignore_file DEADJOE$
 ignore_file \.bak$
 ignore_file %$

--- a/templates/munin-node.conf.j2
+++ b/templates/munin-node.conf.j2
@@ -54,6 +54,12 @@ allow {{ allowed_ip }}
 # cidr_allow 127.0.0.1/32
 # cidr_allow 192.0.2.0/24
 # cidr_deny  192.0.2.42/32
+{% for allowed_cidr in munin_node_allowed_cidrs %}
+cidr_allow {{ allowed_cidr }}
+{% endfor %}
+{% for denied_cidr in munin_node_denied_cidrs %}
+cidr_deny {{ denied_cidr }}
+{% endfor %}
 
 # Which address to bind to;
 host {{ munin_node_bind_host }}

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,3 +1,7 @@
 ---
 munin_node_log: /var/log/munin/munin-node.log
 munin_node_pid: /var/run/munin/munin-node.pid
+munin_node_async_service: munin-async
+munin_node_async_home: /var/lib/munin-async
+munin_node_async_user: munin-async
+munin_node_async_group: munin-async

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,3 +1,7 @@
 ---
 munin_node_log: /var/log/munin-node/munin-node.log
 munin_node_pid: /var/run/munin/munin-node.pid
+munin_node_async_service: munin-asyncd
+munin_node_async_home: /var/lib/munin-async
+munin_node_async_user: munin-async
+munin_node_async_group: munin-async


### PR DESCRIPTION
As described in the README, munin-async allows to monitor nodes asynchronously through SSH.

Besides this, this PR also adds support for `cidr_allow` and `cidr_deny` in munin-node config.