### PR TITLE
Minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Set this explicitly if the munin master doesn't report the correct hostname when
 
     munin_node_allowed_ips:
       - '^127\.0\.0\.1$'
+      - '^::1$'
 
 A list of IP addresses formatted as a python-style regular expression. Must use single quotes to allow the proper regex escaping to pass through to the configuration file. Hosts with these IP addresses will be allowed to connect to the server and get detailed system stats via munin-node.
 

--- a/templates/munin-node.conf.j2
+++ b/templates/munin-node.conf.j2
@@ -21,8 +21,7 @@ group root
 # timeout 60
 
 # Regexps for files to ignore
-ignore_file ~$
-#ignore_file [#~]$  # FIX doesn't work. '#' starts a comment
+ignore_file [\#~]$
 ignore_file DEADJOE$
 ignore_file \.bak$
 ignore_file %$


### PR DESCRIPTION
The regexp fix has been upstream since munin 2.0 in 2010 (d1b05cea06
upstream), so it should be safe.

Update README to reflect default value of munin_node_allowed_ips.