### PR TITLE
Allow unwanted plugins to be disabled.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ If the name of the resulting plugin does not match the name of the munin plugin 
       - name: if_eth0
         plugin: if_
 
+You can also disable plugins using the `munin_node_plugins_disable` list, like so:
+
+    munin_node_plugins_disable:
+      - name: mysql_replication
+
 #### Plugin settings
 
 If you need to add plugin configuration for plugins you've added via `munin_node_plugins`, you can do so with a simple hashmap that has the plugin name (which will be the `[plugin]` section in the resulting configuration file), and a list of variable names and values. For example:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,12 +14,16 @@ munin_plugin_src_path: /usr/share/munin/plugins/
 munin_plugin_dest_path: /etc/munin/plugins/
 
 # List of munin plugins to enable.
-munin_node_plugins: []
+munin_node_plugins_enable: []
 # - name: uptime
 # - name: if_eth0
 #   plugin: if_
 # - name: ps_test
 #   plugin: ps_
+
+# List of munin plugins to disable.
+munin_node_plugins_disable: []
+  # - name: mysql_replication
 
 # Plugin configuration options (the key is the plugin heading, items within will
 # be options for the plugin).

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,14 @@
     path: "{{ munin_plugin_dest_path }}{{ item.name }}"
     src: "{{ munin_plugin_src_path }}{{ item.plugin | default( item.name ) }}"
     state: link
-  with_items: "{{ munin_node_plugins }}"
+  with_items: "{{ munin_node_plugins_enable }}"
+  notify: restart munin-node
+
+- name: Disable unwanted plugins.
+  file:
+    path: "{{ munin_node_plugin_dest_path }}{{ item.plugin | default( item.name ) }}"
+    state: absent
+  with_items: "{{ munin_node_plugins_disable }}"
   notify: restart munin-node
 
 - name: Ensure munin-node is running.


### PR DESCRIPTION
This is useful when you don't want to graph some part of a multigraph
plugin. For instance, you run a MySQL server but you don't need
replication, so you want to disable the `mysql_replication` graph.

I confess I didn't run the tests, since I don't have your molecule setup available - yet.