### PR TITLE
Add support for OpenBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/geerlingguy/ansible-role-munin-node/workflows/CI/badge.svg?event=push)](https://github.com/geerlingguy/ansible-role-munin-node/actions?query=workflow%3ACI)
 
-Installs munin-node, a monitoring system endpoint, on RedHat/CentOS or Debian/Ubuntu Linux servers.
+Installs munin-node, a monitoring system endpoint, on RedHat/CentOS, Debian/Ubuntu, or OpenBSD servers.
 
 ## Requirements
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: restart munin-node
-  service: name=munin-node state=restarted
+  service: name={{ munin_node_service }} state=restarted

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ dependencies: []
 galaxy_info:
   role_name: munin-node
   author: geerlingguy
-  description: Munin node monitoring endpoint for RedHat/CentOS or Debian/Ubuntu.
+  description: Munin node monitoring endpoint for RedHat/CentOS, Debian/Ubuntu and OpenBSD.
   company: "Midwestern Mac, LLC"
   license: "license (BSD, MIT)"
   min_ansible_version: 2.4
@@ -19,6 +19,9 @@ galaxy_info:
       versions:
         - 7
         - 8
+    - name: OpenBSD
+      versions:
+        - all
   galaxy_tags:
     - monitoring
     - system

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,4 +37,4 @@
   notify: restart munin-node
 
 - name: Ensure munin-node is running.
-  service: name=munin-node state=started enabled=yes
+  service: name={{ munin_node_service }} state=started enabled=yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,8 +14,8 @@
   template:
     src: munin-node.conf.j2
     dest: /etc/munin/munin-node.conf
-    owner: root
-    group: root
+    owner: "{{ munin_node_user }}"
+    group: "{{ munin_node_group }}"
     mode: 0644
   notify: restart munin-node
 
@@ -23,8 +23,8 @@
   template:
     src: plugin-conf.j2
     dest: /etc/munin/plugin-conf.d/ansible.conf
-    owner: root
-    group: root
+    owner: "{{ munin_node_user }}"
+    group: "{{ munin_node_group }}"
     mode: 0644
   notify: restart munin-node
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,10 @@
   apt: name=munin-node state=present
   when: ansible_os_family == 'Debian'
 
+- name: Ensure munin-node is installed (OpenBSD).
+  community.general.openbsd_pkg: name=munin-node state=present
+  when: ansible_os_family == 'OpenBSD'
+
 - name: Copy munin-node configuration.
   template:
     src: munin-node.conf.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
   when: ansible_os_family == 'Debian'
 
 - name: Ensure munin-node is installed (OpenBSD).
-  community.general.openbsd_pkg: name=munin-node state=present
+  openbsd_pkg: name=munin-node state=present
   when: ansible_os_family == 'OpenBSD'
 
 - name: Copy munin-node configuration.

--- a/templates/munin-node.conf.j2
+++ b/templates/munin-node.conf.j2
@@ -9,8 +9,8 @@ pid_file {{ munin_node_pid }}
 background 1
 setsid 1
 
-user root
-group root
+user {{ munin_node_user }}
+group {{ munin_node_group }}
 
 # This is the timeout for the whole transaction.
 # Units are in sec. Default is 15 min

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,4 +1,6 @@
 ---
 munin_node_log: /var/log/munin/munin-node.log
 munin_node_pid: /var/run/munin/munin-node.pid
+munin_node_user: root
+munin_node_group: root
 munin_node_service: munin-node

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,3 +1,4 @@
 ---
 munin_node_log: /var/log/munin/munin-node.log
 munin_node_pid: /var/run/munin/munin-node.pid
+munin_node_service: munin-node

--- a/vars/OpenBSD.yml
+++ b/vars/OpenBSD.yml
@@ -1,0 +1,7 @@
+---
+munin_node_log: /var/log/munin/munin-node.log
+munin_node_pid: /var/run/munin/munin-node.pid
+munin_node_user: root
+munin_node_group: wheel
+munin_node_service: munin_node
+munin_plugin_src_path: /usr/local/libexec/munin/plugins/

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,4 +1,6 @@
 ---
 munin_node_log: /var/log/munin-node/munin-node.log
 munin_node_pid: /var/run/munin/munin-node.pid
+munin_node_user: root
+munin_node_group: root
 munin_node_service: munin-node

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,3 +1,4 @@
 ---
 munin_node_log: /var/log/munin-node/munin-node.log
 munin_node_pid: /var/run/munin/munin-node.pid
+munin_node_service: munin-node


### PR DESCRIPTION
The first two commits are necessary to add more configurability, because OpenBSD differs a bit from RedHat and Debian (but not that much, actually).